### PR TITLE
Adjustments for remove-project part

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -11,8 +11,6 @@
   <project path="hardware/rpi" name="hardware_rpi" revision="nougat" remote="arpi"/>
   <project path="device/brcm/rpi3" name="device_brcm_rpi3" revision="nougat" remote="arpi"/>
 
-  <remove-project name="device/google/dragon-kernel" />
-  <remove-project name="device/google/marlin-kernel" />
   <remove-project name="device/htc/flounder-kernel" />
   <remove-project name="device/huawei/angler-kernel" />
   <remove-project name="device/lge/bullhead-kernel" />


### PR DESCRIPTION
repo sync was showing error fatal: remove-project element specifies non-existent project: device/google/dragon-kernel