### PR TITLE
QUESTIONS

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,6 @@
 # Download Android source with patches(local_manifests)
  Refer to http://source.android.com/source/downloading.html
- $ repo init -u https://android.googlesource.com/platform/manifest -b android-o-preview-2
+ $ repo init -u https://android.googlesource.com/platform/manifest -b android-o-preview-3
  $ git clone https://github.com/peyo-hd/local_manifests/tree/opv .repo/local_manifests
  $ repo sync
 

--- a/README
+++ b/README
@@ -1,8 +1,11 @@
 # Download Android source with patches(local_manifests)
  Refer to http://source.android.com/source/downloading.html
- $ repo init -u https://android.googlesource.com/platform/manifest -b android-o-preview-3
+ $ repo init -u https://android.googlesource.com/platform/manifest -b android-o-preview-4
  $ git clone https://github.com/peyo-hd/local_manifests/tree/opv .repo/local_manifests
  $ repo sync
+
+# Apply patch
+  https://github.com/peyo-hd/local_manifests/wiki/Patch-android-o-preview-4
 
 # Build for Raspberry Pi3
  https://github.com/peyo-hd/device_brcm_rpi3/tree/opv

--- a/README
+++ b/README
@@ -1,11 +1,11 @@
 # Download Android source with patches(local_manifests)
  Refer to http://source.android.com/source/downloading.html
- $ repo init -u https://android.googlesource.com/platform/manifest -b android-7.1.2_r4
- $ git clone https://github.com/android-rpi/local_manifests .repo/local_manifests
+ $ repo init -u https://android.googlesource.com/platform/manifest -b android-o-preview-2
+ $ git clone https://github.com/peyo-hd/local_manifests/tree/opv .repo/local_manifests
  $ repo sync
 
 # Build for Raspberry Pi3
- https://github.com/android-rpi/device_brcm_rpi3
+ https://github.com/peyo-hd/device_brcm_rpi3/tree/opv
 
 Use -j[n] option on sync & build steps, if build host has a good number of CPU cores.
 

--- a/default.xml
+++ b/default.xml
@@ -9,7 +9,7 @@
   <project path="external/drm_gralloc" name="external_drm_gralloc" revision="opv" remote="peyo"/>
 
   <project path="kernel/rpi" name="kernel_rpi" revision="opv" remote="peyo"/>
-  <project path="hardware/rpi" name="hardware_rpi" revision="nougat" remote="arpi"/>
+  <project path="hardware/rpi" name="hardware_rpi" revision="opv" remote="peyo"/>
   <project path="device/brcm/rpi3" name="device_brcm_rpi3" revision="opv" remote="peyo"/>
 
   <remove-project name="platform/system/extra"/>

--- a/default.xml
+++ b/default.xml
@@ -12,6 +12,8 @@
   <project path="hardware/rpi" name="hardware_rpi" revision="opv" remote="peyo"/>
   <project path="device/brcm/rpi3" name="device_brcm_rpi3" revision="opv" remote="peyo"/>
 
+  <project path="system/timezone" name="platform/system/timezone" revision="master"/>
+
   <remove-project name="platform/system/extras"/>
   <project path="system/extras" name="platform/system/extras" revision="master"/>
   <remove-project name="platform/external/libexif" />
@@ -26,6 +28,8 @@
   <project path="external/e2fsprogs" name="platform/external/e2fsprogs" revision="master"/>
   <remove-project name="platform/external/f2fs-tools" />
   <project path="external/f2fs-tools" name="platform/external/f2fs-tools" revision="master"/>
+  <remove-project name="platform/external/selinux" />
+  <project path="external/selinux" name="platform/external/selinux" revision="master" />
   
   <remove-project name="device/asus/fugu-kernel" />
   <remove-project name="device/google/dragon-kernel" />

--- a/default.xml
+++ b/default.xml
@@ -6,12 +6,27 @@
   <remove-project name="platform/external/mesa3d"/>
   <project path="external/mesa3d" name="external_mesa3d" revision="opv" remote="peyo"/>
   <remove-project name="platform/external/drm_gralloc"/>
-  <project path="external/drm_gralloc" name="external_drm_gralloc" revision="nougat" remote="arpi"/>
+  <project path="external/drm_gralloc" name="external_drm_gralloc" revision="opv" remote="peyo"/>
 
   <project path="kernel/rpi" name="kernel_rpi" revision="opv" remote="peyo"/>
   <project path="hardware/rpi" name="hardware_rpi" revision="nougat" remote="arpi"/>
   <project path="device/brcm/rpi3" name="device_brcm_rpi3" revision="opv" remote="peyo"/>
 
+  <remove-project name="platform/system/extra"/>
+  <project path="system/extra" name="platform/system/extra" revision="master"/>
+  <remove-project name="platform/external/libexif" />
+  <project path="external/libexif" name="platform/external/libexif" revision="master"/>
+  <remove-project name="platform/external/cblas" />
+  <project path="external/cblas" name="platform/external/cblas" revision="master"/>
+  <remove-project name="platform/external/eigen" />
+  <project path="external/eigen" name="platform/external/eigen" revision="master"/>
+  <remove-project name="platform/external/fio" />
+  <project path="external/fio" name="platform/external/fio" revision="master"/>
+  <remove-project name="platform/external/e2fsprogs" />
+  <project path="external/e2fsprogs" name="platform/external/e2fsprogs" revision="master"/>
+  <remove-project name="platform/external/f2fs-tools/" />
+  <project path="external/f2fs-tools" name="platform/external/f2fs-tools" revision="master"/>
+  
   <remove-project name="device/asus/fugu-kernel" />
   <remove-project name="device/google/dragon-kernel" />
   <remove-project name="device/google/marlin-kernel" />

--- a/default.xml
+++ b/default.xml
@@ -1,21 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
   <remote name="arpi" fetch="https://github.com/android-rpi"/>
+  <remote name="peyo" fetch="https://github.com/peyo-hd"/>
 
   <remove-project name="platform/external/mesa3d"/>
-  <project path="external/mesa3d" name="external_mesa3d" revision="nougat" remote="arpi"/>
+  <project path="external/mesa3d" name="external_mesa3d" revision="opv" remote="peyo"/>
   <remove-project name="platform/external/drm_gralloc"/>
   <project path="external/drm_gralloc" name="external_drm_gralloc" revision="nougat" remote="arpi"/>
 
-  <project path="kernel/rpi" name="kernel_rpi" revision="nougat" remote="arpi"/>
+  <project path="kernel/rpi" name="kernel_rpi" revision="opv" remote="peyo"/>
   <project path="hardware/rpi" name="hardware_rpi" revision="nougat" remote="arpi"/>
-  <project path="device/brcm/rpi3" name="device_brcm_rpi3" revision="nougat" remote="arpi"/>
+  <project path="device/brcm/rpi3" name="device_brcm_rpi3" revision="opv" remote="peyo"/>
 
+  <remove-project name="device/asus/fugu-kernel" />
   <remove-project name="device/google/dragon-kernel" />
+  <remove-project name="device/google/marlin-kernel" />
   <remove-project name="device/htc/flounder-kernel" />
   <remove-project name="device/huawei/angler-kernel" />
   <remove-project name="device/lge/bullhead-kernel" />
   <remove-project name="device/linaro/hikey-kernel" />
-  <remove-project name="device/asus/fugu-kernel" />
   <remove-project name="device/moto/shamu-kernel" />
 </manifest>

--- a/default.xml
+++ b/default.xml
@@ -12,8 +12,8 @@
   <project path="hardware/rpi" name="hardware_rpi" revision="opv" remote="peyo"/>
   <project path="device/brcm/rpi3" name="device_brcm_rpi3" revision="opv" remote="peyo"/>
 
-  <remove-project name="platform/system/extra"/>
-  <project path="system/extra" name="platform/system/extra" revision="master"/>
+  <remove-project name="platform/system/extras"/>
+  <project path="system/extras" name="platform/system/extras" revision="master"/>
   <remove-project name="platform/external/libexif" />
   <project path="external/libexif" name="platform/external/libexif" revision="master"/>
   <remove-project name="platform/external/cblas" />
@@ -24,7 +24,7 @@
   <project path="external/fio" name="platform/external/fio" revision="master"/>
   <remove-project name="platform/external/e2fsprogs" />
   <project path="external/e2fsprogs" name="platform/external/e2fsprogs" revision="master"/>
-  <remove-project name="platform/external/f2fs-tools/" />
+  <remove-project name="platform/external/f2fs-tools" />
   <project path="external/f2fs-tools" name="platform/external/f2fs-tools" revision="master"/>
   
   <remove-project name="device/asus/fugu-kernel" />


### PR DESCRIPTION
Hi,
I have few questions. Please help.
I have Raspberry Pi2 and I wanted to boot Android N or O into it.
I also have AOSP setup for Android and raspberry pi kernel source.
I followed the steps as per peyo-hd github and I could able to get rpi3-eng under lunch memory under AOSP. But I wanted to build rpi2-eng. This option is not coming under lunch.
Please let me know how to include rpi2-eng and build it.
When I try to pull local_manifests, I only get rpi3, not rpi2.
How can I change it rpi2?
Can I simply build for rpi3-eng (32-bit) and use that image on raspberry pi2?

Please help me with the setps for rpi2-eng.

Thanks