### PR TITLE
Add `README.md` for GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+## Download Android source with local_manifests
+
+Refer to http://source.android.com/source/downloading.html
+
+```bash
+$ repo init -u https://android.googlesource.com/platform/manifest -b android-12.0.0_r27
+$ git clone https://github.com/android-rpi/local_manifests .repo/local_manifests -b arpi-12
+$ repo sync
+```
+
+## Build for Raspberry Pi 4
+
+https://github.com/android-rpi/device_arpi_rpi4
+
+Use `-j[n]` option on sync & build steps, if build host has a good number of CPU cores.


### PR DESCRIPTION
This PR adds a stylised markdown version of the `README` file for GitHub to display. **It does not replace the original file.**

## Original:
![image](https://user-images.githubusercontent.com/71089234/152653916-6033018d-40c7-43e8-88e8-2f045924dd4d.png)

## Markdown:
![image](https://user-images.githubusercontent.com/71089234/152653892-a70e6092-976b-4520-9591-c322e09d5c58.png)
